### PR TITLE
fix shebang in gMetaDataParse.py

### DIFF
--- a/gMetaDataParse.py
+++ b/gMetaDataParse.py
@@ -1,4 +1,4 @@
-#!/usb/bin/env python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # Author: twitter: @b00010111


### PR DESCRIPTION
The typo in the shebang prevented the execution with the py launcher or under linux without specifying the interpreter